### PR TITLE
Fix: Remove new header, revert to old header

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,11 +11,6 @@
 </head>
 <body>
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">


### PR DESCRIPTION
Removes the "Course Materials Assistant" header and subtitle from the frontend, reverting to the previous header style while keeping the theme toggle intact.

Closes #2

Generated with [Claude Code](https://claude.ai/code)